### PR TITLE
Link phenotype to single state by matrix cell

### DIFF
--- a/rdf_generator/main.py
+++ b/rdf_generator/main.py
@@ -954,9 +954,17 @@ def build_cdao_matrix(
 
             # Link exactly one state (if resolvable) to the cell phenotype instance
             if chosen_state_node is not None:
+                # Phenotype has this quality/state (single)
                 g.add((per_pheno_uri, PHB.has_quality_component, chosen_state_node))
-                # Also assert has_characteristic from per-cell phenotype to the specific state
-                g.add((per_pheno_uri, PHB.has_characteristic, chosen_state_node))
+
+                # Connect either Variable (preferred) or last Locator to the state via has_characteristic
+                if var_instance is not None:
+                    g.add((var_instance, PHB.has_characteristic, chosen_state_node))
+                elif locator_instances:
+                    last_locator = locator_instances[-1]
+                    g.add((last_locator, PHB.has_characteristic, chosen_state_node))
+
+                # Cell also points to the state
                 g.add((cell_uri, CDAO["0000184"], chosen_state_node))  # Cell has_state
 
             # Link Cell → Phenotype (to the per-cell instance)


### PR DESCRIPTION
Refactor phenotype generation to create a unique phenotype instance for each matrix cell, linking it to exactly one state.

This change ensures that each phenotype statement (via `PHB.has_quality_component`) is connected to only one state, as determined by the matrix cell value, rather than linking character-level phenotypes to all possible states.

---
<a href="https://cursor.com/background-agent?bcId=bc-c9ff6be0-f01f-4b2f-90d6-42e423dc0da1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c9ff6be0-f01f-4b2f-90d6-42e423dc0da1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

